### PR TITLE
Fix PDF rendering for the documentation page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-Immunoinformatics/__pycache__/*
-Immunoinformatics/Include/Blocks/__pycache__/*
-Immunoinformatics/Include/Configs/__pycache__/*
-Immunoinformatics/deps/*
-Immunoinformatics/Include/Blocks/test.ipynb
+Immunoinformatics/deps/
+
+*.ipynb
+
+__pycache__/

--- a/Immunoinformatics/Pages/index.html
+++ b/Immunoinformatics/Pages/index.html
@@ -1,20 +1,55 @@
 <!DOCTYPE html>
-<html style="height:100%;">
-<head>
+<html style="height: 100%">
+  <head>
     <title>PredIG</title>
     <style>
-        body, html {
-            margin: 0;
-            padding: 0;
-            height: 100%;
-            width: 100%;
-        }
-        .pdfobject-container { height: 100%; height: 100%; border: 5px solid #ccc; }
+      body,
+      html {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        width: 100%;
+      }
     </style>
-</head>
-<body>
+    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@2.11.338/build/pdf.min.js"></script>
+  </head>
+  <body>
     <div id="docu-pdf"></div>
-</body>
-<script src="https://unpkg.com/pdfobject"></script>
-<script>PDFObject.embed("predig_server_readmes.pdf", "#docu-pdf");</script>
+    <script>
+      var url = "predig_server_readmes.pdf";
+
+      var pdfjsLib = window["pdfjs-dist/build/pdf"];
+
+      // Asynchronous download of PDF
+      pdfjsLib.getDocument(url).promise.then(function (pdf) {
+        // Get the number of pages
+        var numPages = pdf.numPages;
+
+        // Loop through each page
+        for (let pageNum = 1; pageNum <= numPages; pageNum++) {
+          // Fetch the page
+          pdf.getPage(pageNum).then(function (page) {
+            var scale = 1.5;
+            var viewport = page.getViewport({ scale: scale });
+
+            // Prepare canvas using PDF page dimensions
+            var canvas = document.createElement("canvas");
+            canvas.className = "pdf-page";
+            var context = canvas.getContext("2d");
+            canvas.height = viewport.height;
+            canvas.width = viewport.width;
+
+            // Append canvas to the container
+            document.getElementById("docu-pdf").appendChild(canvas);
+
+            // Render PDF page into canvas context
+            page.render({
+              canvasContext: context,
+              viewport: viewport,
+            });
+          });
+        }
+      });
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
- Use a new library to render the PDF directly into the canvas
- Updated `.gitignore` to not track all `__pycache__` folders